### PR TITLE
making it compatible to mono

### DIFF
--- a/GSMCommShared/GSMCommShared.csproj
+++ b/GSMCommShared/GSMCommShared.csproj
@@ -1,7 +1,7 @@
-<?xml version="1.0"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <ProjectGuid>{71ea4054-a98a-46ba-84fa-81652db72b72}</ProjectGuid>
+    <ProjectGuid>{71EA4054-A98A-46BA-84FA-81652DB72B72}</ProjectGuid>
     <SchemaVersion>2</SchemaVersion>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -30,7 +30,6 @@
     <ErrorReport>prompt</ErrorReport>
     <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
-  <ItemGroup />
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs">
       <AutoGen>false</AutoGen>
@@ -52,6 +51,11 @@
       <AutoGen>false</AutoGen>
       <DesignTimeSharedInput>false</DesignTimeSharedInput>
     </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="PDUConverter">
+      <HintPath>C:\GSMComm\DotNet40\PDUConverter.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/GSMCommunication/GSMCommunication.csproj
+++ b/GSMCommunication/GSMCommunication.csproj
@@ -32,10 +32,17 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="PDUConverter, Version=1.21.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>C:\GSMComm\DotNet40\PDUConverter.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="GsmCommunication\EnhancedSerialPort.cs">
+      <SubType>Component</SubType>
+    </Compile>
     <Compile Include="Properties\AssemblyInfo.cs">
       <AutoGen>false</AutoGen>
       <DesignTimeSharedInput>false</DesignTimeSharedInput>
@@ -245,10 +252,6 @@
     <ProjectReference Include="..\GSMCommShared\GSMCommShared.csproj">
       <Project>{71ea4054-a98a-46ba-84fa-81652db72b72}</Project>
       <Name>GSMCommShared</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\PDUConverter\PDUConverter.csproj">
-      <Project>{5e657efe-0a30-466d-b025-ff177e23a727}</Project>
-      <Name>PDUConverter</Name>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/GSMCommunication/GsmCommunication/EnhancedSerialPort.cs
+++ b/GSMCommunication/GsmCommunication/EnhancedSerialPort.cs
@@ -1,0 +1,154 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.IO.Ports;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace GsmComm.GsmCommunication
+{
+    public class EnhancedSerialPort : SerialPort
+    {
+        public EnhancedSerialPort()
+            : base()
+        {
+        }
+
+        public EnhancedSerialPort(IContainer container)
+            : base(container)
+        {
+        }
+
+        public EnhancedSerialPort(string portName)
+            : base(portName)
+        {
+        }
+
+        public EnhancedSerialPort(string portName, int baudRate)
+            : base(portName, baudRate)
+        {
+        }
+
+        public EnhancedSerialPort(string portName, int baudRate, Parity parity)
+            : base(portName, baudRate, parity)
+        {
+        }
+
+        public EnhancedSerialPort(string portName, int baudRate, Parity parity, int dataBits)
+            : base(portName, baudRate, parity, dataBits)
+        {
+        }
+
+        public EnhancedSerialPort(string portName, int baudRate, Parity parity, int dataBits, StopBits stopBits)
+            : base(portName, baudRate, parity, dataBits, stopBits)
+        {
+        }
+
+        // private member access via reflection
+        int fd;
+        FieldInfo disposedFieldInfo;
+        object data_received;
+
+        public new void Open()
+        {
+            base.Open();
+
+            if (IsWindows == false)
+            {
+                FieldInfo fieldInfo = BaseStream.GetType().GetField("fd", BindingFlags.Instance | BindingFlags.NonPublic);
+                fd = (int)fieldInfo.GetValue(BaseStream);
+                disposedFieldInfo = BaseStream.GetType().GetField("disposed", BindingFlags.Instance | BindingFlags.NonPublic);
+                fieldInfo = typeof(SerialPort).GetField("data_received", BindingFlags.Instance | BindingFlags.NonPublic);
+                data_received = fieldInfo.GetValue(this);
+
+                new System.Threading.Thread(new System.Threading.ThreadStart(this.EventThreadFunction)).Start();
+            }
+        }
+
+        static bool IsWindows
+        {
+            get
+            {
+                PlatformID id = Environment.OSVersion.Platform;
+                return id == PlatformID.Win32Windows || id == PlatformID.Win32NT; // WinCE not supported
+            }
+        }
+
+        private void EventThreadFunction()
+        {
+            do
+            {
+                try
+                {
+                    var _stream = BaseStream;
+                    if (_stream == null)
+                    {
+                        return;
+                    }
+                    if (Poll(_stream, ReadTimeout) || BytesToRead > 0)
+                    {
+                        OnDataReceived(null);
+                    }
+                }
+                catch
+                {
+                    return;
+                }
+            }
+            while (IsOpen);
+        }
+
+        void OnDataReceived(SerialDataReceivedEventArgs args)
+        {
+            SerialDataReceivedEventHandler handler = (SerialDataReceivedEventHandler)Events[data_received];
+
+            if (handler != null)
+            {
+                handler(this, args);
+            }
+        }
+
+        [DllImport("MonoPosixHelper", SetLastError = true)]
+        static extern bool poll_serial(int fd, out int error, int timeout);
+
+        private bool Poll(Stream stream, int timeout)
+        {
+            CheckDisposed(stream);
+            if (IsOpen == false)
+            {
+                throw new Exception("port is closed");
+            }
+            int error;
+
+            bool poll_result = poll_serial(fd, out error, ReadTimeout);
+            if (error == -1)
+            {
+                ThrowIOException();
+            }
+            return poll_result;
+        }
+
+        [DllImport("libc")]
+        static extern IntPtr strerror(int errnum);
+
+        static void ThrowIOException()
+        {
+            int errnum = Marshal.GetLastWin32Error();
+            string error_message = Marshal.PtrToStringAnsi(strerror(errnum));
+
+            throw new IOException(error_message);
+        }
+
+        void CheckDisposed(Stream stream)
+        {
+            bool disposed = (bool)disposedFieldInfo.GetValue(stream);
+            if (disposed)
+            {
+                throw new ObjectDisposedException(stream.GetType().FullName);
+            }
+        }
+    }
+}

--- a/GSMCommunication/GsmCommunication/GsmCommMain.cs
+++ b/GSMCommunication/GsmCommunication/GsmCommMain.cs
@@ -517,18 +517,24 @@ namespace GsmComm.GsmCommunication
 		/// </remarks>
 		public void EnableMessageNotifications()
 		{
+            
 			MessageIndicationSupport supportedIndications = this.theDevice.GetSupportedIndications();
-			MessageIndicationMode messageIndicationMode = MessageIndicationMode.BufferAndFlush;
-			if (!supportedIndications.SupportsMode(messageIndicationMode))
+            
+            MessageIndicationMode messageIndicationMode = MessageIndicationMode.BufferAndFlush;
+            
+            if (!supportedIndications.SupportsMode(messageIndicationMode))
 			{
+                
 				if (supportedIndications.SupportsMode(MessageIndicationMode.SkipWhenReserved))
 				{
+                    
 					messageIndicationMode = MessageIndicationMode.SkipWhenReserved;
 				}
 				else
 				{
 					if (supportedIndications.SupportsMode(MessageIndicationMode.ForwardAlways))
 					{
+                        
 						messageIndicationMode = MessageIndicationMode.ForwardAlways;
 					}
 					else
@@ -537,8 +543,10 @@ namespace GsmComm.GsmCommunication
 					}
 				}
 			}
+            
 			SmsDeliverIndicationStyle smsDeliverIndicationStyle = SmsDeliverIndicationStyle.RouteMemoryLocation;
-			if (supportedIndications.SupportsDeliverStyle(smsDeliverIndicationStyle))
+            
+            if (supportedIndications.SupportsDeliverStyle(smsDeliverIndicationStyle))
 			{
 				CbmIndicationStyle cbmIndicationStyle = CbmIndicationStyle.Disabled;
 				SmsStatusReportIndicationStyle smsStatusReportIndicationStyle = SmsStatusReportIndicationStyle.RouteMemoryLocation;
@@ -548,6 +556,7 @@ namespace GsmComm.GsmCommunication
 					smsStatusReportIndicationStyle = SmsStatusReportIndicationStyle.Disabled;
 				}
 				IndicationBufferSetting indicationBufferSetting = IndicationBufferSetting.Flush;
+                
 				if (!supportedIndications.SupportsBufferSetting(indicationBufferSetting))
 				{
 					if (supportedIndications.SupportsBufferSetting(IndicationBufferSetting.Clear))
@@ -559,6 +568,7 @@ namespace GsmComm.GsmCommunication
 						throw new CommException("The phone does not support any of the required buffer settings.");
 					}
 				}
+                
 				MessageIndicationSettings messageIndicationSetting = new MessageIndicationSettings(messageIndicationMode, smsDeliverIndicationStyle, cbmIndicationStyle, smsStatusReportIndicationStyle, indicationBufferSetting);
 				this.theDevice.SetMessageIndications(messageIndicationSetting);
 				return;

--- a/GSMCommunication/GsmCommunication/GsmPhone.cs
+++ b/GSMCommunication/GsmCommunication/GsmPhone.cs
@@ -25,7 +25,7 @@ namespace GsmComm.GsmCommunication
 
 		private const string mobileEquipmentErrorPattern = "\\r\\n\\+CME ERROR: (\\d+)\\r\\n";
 
-		private SerialPort port;
+		private EnhancedSerialPort port;
 
 		private string portName;
 
@@ -434,7 +434,7 @@ namespace GsmComm.GsmCommunication
 					}
 					else
 					{
-						if (this.CommThreadReceive())
+                        if (this.CommThreadReceive())
 						{
 							timer.Stop();
 							this.checkConnection.Reset();
@@ -2378,7 +2378,7 @@ namespace GsmComm.GsmCommunication
 		/// <seealso cref="M:GsmComm.GsmCommunication.GsmPhone.IsOpen" />
 		/// <seealso cref="M:GsmComm.GsmCommunication.GsmPhone.Close" />
 		/// </remarks>
-		/// <exception cref="T:System.InvalidOperationException">Connection to device already open.</exception>
+		/// <exception cref="T:Systestem.InvalidOperationException">Connection to device already open.</exception>
 		/// <exception cref="T:GsmComm.GsmCommunication.CommException">Unable to open the port.</exception>
 		public void Open()
 		{
@@ -2435,8 +2435,10 @@ namespace GsmComm.GsmCommunication
 			}
 			else
 			{
-				SerialPortFixer.Execute(portName);
-				this.port = new SerialPort();
+				//SerialPortFixer.Execute(portName);
+				//this.port = new SerialPort();
+                this.port = new EnhancedSerialPort();
+                
 			}
 			try
 			{
@@ -2533,10 +2535,11 @@ namespace GsmComm.GsmCommunication
 
 		private void port_DataReceived(object sender, SerialDataReceivedEventArgs e)
 		{
-			if (e.EventType == SerialData.Chars)
-			{
+			//if (e.EventType == SerialData.Chars)
+			//{
 				this.receiveNow.Set();
-			}
+            
+			//}
 		}
 
 		/// <summary>
@@ -2635,10 +2638,14 @@ namespace GsmComm.GsmCommunication
 		private bool ReceiveInternal(out string input)
 		{
 			StringBuilder stringBuilder = new StringBuilder();
-			for (string i = this.port.ReadExisting(); i.Length > 0; i = this.port.ReadExisting())
+			/*for (string i = this.port.ReadExisting(); i.Length > 0; i = this.port.ReadExisting())
 			{
 				stringBuilder.Append(i);
-			}
+			}*/
+		    while (port.BytesToRead > 0)
+		    {
+		        stringBuilder.Append((char)port.ReadByte());
+		    }
 			input = stringBuilder.ToString();
 			return input.Length > 0;
 		}
@@ -2882,7 +2889,11 @@ namespace GsmComm.GsmCommunication
 			}
 			this.port.DiscardOutBuffer();
 			this.port.DiscardInBuffer();
-			this.port.Write(output);
+			//this.port.Write(output);
+
+		    byte[] bytes = Encoding.ASCII.GetBytes(output);
+
+            port.Write(bytes, 0, bytes.Length);
 		}
 
 		/// <summary>

--- a/GSMCommunication/GsmCommunication/MessageIndicationSupport.cs
+++ b/GSMCommunication/GsmCommunication/MessageIndicationSupport.cs
@@ -135,7 +135,7 @@ namespace GsmComm.GsmCommunication
 		/// <returns>true if the setting is supported, false otherwise.</returns>
 		public bool SupportsBufferSetting(IndicationBufferSetting setting)
 		{
-			return this.SupportsBufferSetting(setting);
+			return this.SupportsBufferSetting((int)setting);
 		}
 
 		/// <summary>
@@ -166,6 +166,7 @@ namespace GsmComm.GsmCommunication
 		/// <returns>true if the style is supported, false otherwise.</returns>
 		public bool SupportsDeliverStyle(int style)
 		{
+            
 			ArrayList arrayLists = this.ParseArrayAsString(this.deliver);
 			return arrayLists.Contains(style);
 		}
@@ -177,7 +178,8 @@ namespace GsmComm.GsmCommunication
 		/// <returns>true if the style is supported, false otherwise.</returns>
 		public bool SupportsDeliverStyle(SmsDeliverIndicationStyle style)
 		{
-			return this.SupportsDeliverStyle(style);
+            
+			return this.SupportsDeliverStyle((int)style);
 		}
 
 		/// <summary>
@@ -187,8 +189,8 @@ namespace GsmComm.GsmCommunication
 		/// <returns>true if the mode is supported, false otherwise.</returns>
 		public bool SupportsMode(int mode)
 		{
-			ArrayList arrayLists = this.ParseArrayAsString(this.mode);
-			return arrayLists.Contains(mode);
+            ArrayList arrayLists = this.ParseArrayAsString(this.mode);
+            return arrayLists.Contains(mode);
 		}
 
 		/// <summary>
@@ -198,7 +200,7 @@ namespace GsmComm.GsmCommunication
 		/// <returns>true if the mode is supported, false otherwise.</returns>
 		public bool SupportsMode(MessageIndicationMode mode)
 		{
-			return this.SupportsMode(mode);
+			return this.SupportsMode((int)mode);
 		}
 
 		/// <summary>
@@ -219,7 +221,7 @@ namespace GsmComm.GsmCommunication
 		/// <returns>true if the style is supported, false otherwise.</returns>
 		public bool SupportsStatusReportStyle(SmsStatusReportIndicationStyle style)
 		{
-			return this.SupportsStatusReportStyle(style);
+			return this.SupportsStatusReportStyle((int)style);
 		}
 	}
 }

--- a/PDUConverter/GsmComm.PduConverter/SmsPdu.cs
+++ b/PDUConverter/GsmComm.PduConverter/SmsPdu.cs
@@ -209,9 +209,10 @@ namespace GsmComm.PduConverter
 				if (dataCodingScheme.Alphabet != 2)
 				{
 					this.Encode7BitText(value);
+                    Console.WriteLine("Using 7 bit!");
 					return;
 				}
-				else
+				else 
 				{
 					this.EncodeUcs2Text(value);
 					return;

--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+# GSMComm
+GSM SMS library for C#
+
+This is a fork of welly87/GSMComm, which itself is a decompilation of the GSMComm library (http://www.scampers.org/steve/sms/libraries.htm).
+
+Since this is not the original code, it's quite buggy when it comes to PDU conversion. But the communication part is working OK.
+
+I made the implementation compatible to the mono framework, which does not support the DataReceived callback of the serialport class.


### PR DESCRIPTION
Since this implementation is quite buggy when it comes to PDU-Conversion, the use of the "original"/"Closed-source" library for these means is to be considered.

But at least my pull request makes it compatible to mono... by making a new implementation above serialport, which fires a DataReceived event.
